### PR TITLE
Avoid integer overflow and initialize memory before use

### DIFF
--- a/external/sign.h
+++ b/external/sign.h
@@ -1,3 +1,8 @@
+/*=============================================================================
+ * Copyright (c) 2022 by SandboxAQ Inc
+ * Author: Duc Tri Nguyen (ductri.nguyen@sandboxaq.com)
+ * SPDX-License-Identifier: MIT
+=============================================================================*/
 #ifndef API_H
 #define API_H
 

--- a/external/wots.c
+++ b/external/wots.c
@@ -15,7 +15,7 @@ static void expand_seed(const xmss_params *params,
                         unsigned char *outseeds, const unsigned char *inseed, 
                         const unsigned char *pub_seed, uint32_t addr[8])
 {
-    uint32_t i;
+    unsigned int i;
     unsigned char buf[params->n + 32];
 
     set_hash_addr(addr, 0);
@@ -40,7 +40,7 @@ static void gen_chain(const xmss_params *params,
                       unsigned int start, unsigned int steps,
                       const unsigned char *pub_seed, uint32_t addr[8])
 {
-    uint32_t i;
+    unsigned int i;
 
     /* Initialize out with the value at position 'start'. */
     memcpy(out, in, params->n);
@@ -58,13 +58,13 @@ static void gen_chain(const xmss_params *params,
  * This only works when log_w is a divisor of 8.
  */
 static void base_w(const xmss_params *params,
-                   int *output, const int out_len, const unsigned char *input)
+                   unsigned int *output, const unsigned int out_len, const unsigned char *input)
 {
-    int in = 0;
-    int out = 0;
+    unsigned int in = 0;
+    unsigned int out = 0;
     unsigned char total;
-    int bits = 0;
-    int consumed;
+    unsigned int bits = 0;
+    unsigned int consumed;
 
     for (consumed = 0; consumed < out_len; consumed++) {
         if (bits == 0) {
@@ -80,7 +80,7 @@ static void base_w(const xmss_params *params,
 
 /* Computes the WOTS+ checksum over a message (in base_w). */
 static void wots_checksum(const xmss_params *params,
-                          int *csum_base_w, const int *msg_base_w)
+                          unsigned int *csum_base_w, const unsigned int *msg_base_w)
 {
     int csum = 0;
     unsigned char csum_bytes[(params->wots_len2 * params->wots_log_w + 7) / 8];
@@ -100,7 +100,7 @@ static void wots_checksum(const xmss_params *params,
 
 /* Takes a message and derives the matching chain lengths. */
 static void chain_lengths(const xmss_params *params,
-                          int *lengths, const unsigned char *msg)
+                          unsigned int *lengths, const unsigned char *msg)
 {
     base_w(params, lengths, params->wots_len1, msg);
     wots_checksum(params, lengths + params->wots_len1, lengths);
@@ -118,7 +118,7 @@ void wots_pkgen(const xmss_params *params,
                 unsigned char *pk, const unsigned char *seed,
                 const unsigned char *pub_seed, uint32_t addr[8])
 {
-    uint32_t i;
+    unsigned int i;
 
     /* The WOTS+ private key is derived from the seed. */
     expand_seed(params, pk, seed, pub_seed, addr);
@@ -139,8 +139,10 @@ void wots_sign(const xmss_params *params,
                const unsigned char *seed, const unsigned char *pub_seed,
                uint32_t addr[8])
 {
-    int lengths[params->wots_len];
-    uint32_t i;
+    unsigned int lengths[params->wots_len];
+    unsigned int i;
+
+    memset(lengths, 0, sizeof(unsigned int)*params->wots_len);
 
     chain_lengths(params, lengths, msg);
 
@@ -163,8 +165,10 @@ void wots_pk_from_sig(const xmss_params *params, unsigned char *pk,
                       const unsigned char *sig, const unsigned char *msg,
                       const unsigned char *pub_seed, uint32_t addr[8])
 {
-    int lengths[params->wots_len];
-    uint32_t i;
+    unsigned int lengths[params->wots_len];
+    unsigned int i;
+
+    memset(lengths, 0, sizeof(unsigned int)*params->wots_len);
 
     chain_lengths(params, lengths, msg);
 

--- a/external/xmss_core.c
+++ b/external/xmss_core.c
@@ -230,7 +230,7 @@ int xmssmt_core_sign(const xmss_params *params,
         memset(sk + params->index_bytes, 0, (params->sk_bytes - params->index_bytes));
         if (idx > ((1ULL << params->full_height) - 1))
             return -2; // We already used all one-time keys
-        if ((params->full_height == 64) && (idx == ((1ULL << params->full_height) - 1))) 
+        if ((params->full_height == 64) && (idx == UINT64_MAX))
                 return -2; // We already used all one-time keys
     }
     


### PR DESCRIPTION
Improve robustness of the code, avoid integer overflow and initialized memory before use. 

